### PR TITLE
Add CartoDBLayer support for layer names.

### DIFF
--- a/cartodb-gmapsv3.js
+++ b/cartodb-gmapsv3.js
@@ -58,7 +58,8 @@ if (typeof(google.maps.CartoDBLayer) === "undefined") {
 	      getTileUrl: function(coord, zoom) {
 	        return 'http://' + params.user_name + '.cartodb.com/tiles/' + params.table_name + '/'+zoom+'/'+coord.x+'/'+coord.y+'.png?sql='+params.query;
 	      },
-	      tileSize: new google.maps.Size(256, 256)
+	      tileSize: new google.maps.Size(256, 256),
+         name: params.tile_name
 	    };
 	    var cartodb_imagemaptype = new google.maps.ImageMapType(cartodb_layer);
 	    params.map.overlayMapTypes.insertAt(0, cartodb_imagemaptype);
@@ -137,7 +138,8 @@ if (typeof(google.maps.CartoDBLayer) === "undefined") {
 	      getTileUrl: function(coord, zoom) {
 	        return 'http://' + params.user_name + '.cartodb.com/tiles/' + params.table_name + '/'+zoom+'/'+coord.x+'/'+coord.y+'.png?sql='+params.query;
 	      },
-	      tileSize: new google.maps.Size(256, 256)
+	      tileSize: new google.maps.Size(256, 256),
+         name: params.tile_name
 	    };
 	    var cartodb_imagemaptype = new google.maps.ImageMapType(cartodb_layer);
 	    params.map.overlayMapTypes.insertAt(0, cartodb_imagemaptype);
@@ -209,7 +211,8 @@ if (typeof(google.maps.CartoDBLayer) === "undefined") {
     			  getTileUrl: function(coord, zoom) {
     			  return 'http://' + params.user_name + '.cartodb.com/tiles/' + params.table_name + '/'+zoom+'/'+coord.x+'/'+coord.y+'.png?sql='+params.query;
     		  },
-  			  tileSize: new google.maps.Size(256, 256)
+  			  tileSize: new google.maps.Size(256, 256),
+           name: params.tile_name
   	    };
   	    
   	    var cartodb_imagemaptype = new google.maps.ImageMapType(cartodb_layer);
@@ -241,6 +244,7 @@ if (typeof(google.maps.CartoDBLayer) === "undefined") {
         grids: [grid_url],
         tiles_base: tile_url,
         grids_base: grid_url,
+        name: params.tile_name,
         formatter: function(options, data) {
             currentCartoDbId = data.cartodb_id;
             return data.cartodb_id;

--- a/cartodb-gmapsv3.js
+++ b/cartodb-gmapsv3.js
@@ -59,7 +59,7 @@ if (typeof(google.maps.CartoDBLayer) === "undefined") {
 	        return 'http://' + params.user_name + '.cartodb.com/tiles/' + params.table_name + '/'+zoom+'/'+coord.x+'/'+coord.y+'.png?sql='+params.query;
 	      },
 	      tileSize: new google.maps.Size(256, 256),
-         name: params.tile_name
+	      name: params.tile_name
 	    };
 	    var cartodb_imagemaptype = new google.maps.ImageMapType(cartodb_layer);
 	    params.map.overlayMapTypes.insertAt(0, cartodb_imagemaptype);
@@ -139,7 +139,7 @@ if (typeof(google.maps.CartoDBLayer) === "undefined") {
 	        return 'http://' + params.user_name + '.cartodb.com/tiles/' + params.table_name + '/'+zoom+'/'+coord.x+'/'+coord.y+'.png?sql='+params.query;
 	      },
 	      tileSize: new google.maps.Size(256, 256),
-         name: params.tile_name
+	      name: params.tile_name
 	    };
 	    var cartodb_imagemaptype = new google.maps.ImageMapType(cartodb_layer);
 	    params.map.overlayMapTypes.insertAt(0, cartodb_imagemaptype);
@@ -212,7 +212,7 @@ if (typeof(google.maps.CartoDBLayer) === "undefined") {
     			  return 'http://' + params.user_name + '.cartodb.com/tiles/' + params.table_name + '/'+zoom+'/'+coord.x+'/'+coord.y+'.png?sql='+params.query;
     		  },
   			  tileSize: new google.maps.Size(256, 256),
-           name: params.tile_name
+  			  name: params.tile_name
   	    };
   	    
   	    var cartodb_imagemaptype = new google.maps.ImageMapType(cartodb_layer);


### PR DESCRIPTION
This pull request modifies `CartoDBLayer` so that it allows the client to pass in a `tile_name` parameter:

``` javascript

new google.maps.CartoDBLayer({
    tile_name: 'my_layer_name',
    // Other parameters...
});
```

This allows clients to later identify their layers when pulling them from `map.overlayMapTypes()`:

``` javascript
map.overlayMapTypes().forEach(
    function(overlay) {
        if (overlay.name === 'my_layer_name') {
            console.log("BOOM!");
        }
    }
);
```
