### PR TITLE
Fixes wax fork issue with uglifier

### DIFF
--- a/wax.g.js
+++ b/wax.g.js
@@ -1836,7 +1836,7 @@ wax.movetip = function(options) {
     function getTooltip(feature, context) {
         var tooltip = document.createElement('div');
         tooltip.className = 'wax-movetip';
-        tooltip.style.cssText = 'position:absolute;'
+        tooltip.style.cssText = 'position:absolute;';
         tooltip.innerHTML = feature;
         context.appendChild(tooltip);
         _context = context;


### PR DESCRIPTION
Missing semi colon in the modified wax lib was breaking when uglifier tries to compile
